### PR TITLE
Update Python version for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ branches:
   - gh-pages  # Explicitly allow gh-pages
 
 python:
-  - 2.7
-  - 3.4
   - 3.5
+  - 3.7
 
 before_install:
   - git config user.name "Astrobot"


### PR DESCRIPTION
The version of pyyaml that pip installs is no longer compatible with Python 3.4,
but there is also no reason to test for it any longer.