### PR TITLE
Update BibTeX entry for SciPy

### DIFF
--- a/entries/codes/scipy.yaml
+++ b/entries/codes/scipy.yaml
@@ -1,14 +1,33 @@
 name: SciPy
 category: codes
 tags: python
-text: This research made use of SciPy (Jones et al. 2001)
-latex: This research made use of SciPy \citep{jones_scipy_2001}
-url: http://www.scipy.org/
+text: This research made use of SciPy (Virtanen et al. 2020)
+latex: This research made use of SciPy \citep{Virtanen_2020}
+url: https://www.scipy.org
 dependencies:
 bibtex: >
-    @misc{jones_scipy_2001,
-        title = {{SciPy}: Open source scientific tools for Python},
-        url = {http://www.scipy.org/},
-        collaborator = {Jones, E. and Oliphant, T. and Peterson, P. and Others},
-        year = {2001}
+    @Article{         Virtanen_2020,
+      title         = {{SciPy 1.0: Fundamental Algorithms for Scientific
+                      Computing in Python}},
+      author        = {{Virtanen}, Pauli and {Gommers}, Ralf and {Oliphant},
+                      Travis E. and {Haberland}, Matt and {Reddy}, Tyler and
+                      {Cournapeau}, David and {Burovski}, Evgeni and {Peterson},
+                      Pearu and {Weckesser}, Warren and {Bright}, Jonathan and
+                      {van der Walt}, St{\'e}fan J. and {Brett}, Matthew and
+                      {Wilson}, Joshua and {Jarrod Millman}, K. and {Mayorov},
+                      Nikolay and {Nelson}, Andrew R.~J. and {Jones}, Eric and
+                      {Kern}, Robert and {Larson}, Eric and {Carey}, CJ and
+                      {Polat}, {\.I}lhan and {Feng}, Yu and {Moore}, Eric W. and
+                      {Vand erPlas}, Jake and {Laxalde}, Denis and {Perktold},
+                      Josef and {Cimrman}, Robert and {Henriksen}, Ian and
+                      {Quintero}, E.~A. and {Harris}, Charles R and {Archibald},
+                      Anne M. and {Ribeiro}, Ant{\^o}nio H. and {Pedregosa},
+                      Fabian and {van Mulbregt}, Paul and {Contributors}, SciPy
+                      1.0},
+      year          = {2020},
+      journal       = {Nature Methods},
+      volume        = {17},
+      pages         = {261--272},
+      doi           = {https://doi.org/10.1038/s41592-019-0686-2},
+      adsurl        = {https://rdcu.be/b08Wh}
     }


### PR DESCRIPTION
I updated the BibTeX entry to the new [SciPy 1.0 paper](https://www.nature.com/articles/s41592-019-0686-2), which is now [the recommended citation](https://www.scipy.org/citing.html) :)